### PR TITLE
Simplify SQL for selecting an entire table

### DIFF
--- a/lib/Fey/Role/TableLike.pm
+++ b/lib/Fey/Role/TableLike.pm
@@ -8,6 +8,8 @@ use Moose::Role;
 
 with 'Fey::Role::Joinable';
 
+requires 'sql_for_select_clause';
+
 1;
 
 # ABSTRACT: A role for things that are like a table

--- a/lib/Fey/SQL/Select.pm
+++ b/lib/Fey/SQL/Select.pm
@@ -114,15 +114,8 @@ sub select {
         MX_PARAMS_VALIDATE_NO_CACHE => 1,
     );
 
-    for my $elt (
-        map {
-            $_->can('columns')
-                ? sort { $a->name() cmp $b->name() } $_->columns()
-                : $_
-        }
-        map { blessed $_ ? $_ : Fey::Literal->new_from_scalar($_) } @select
-        ) {
-        $self->_add_select_element($elt);
+    for my $elt (@select) {
+        $self->_add_select_element( blessed $elt ? $elt : Fey::Literal->new_from_scalar($elt) );
     }
 
     return $self;
@@ -385,7 +378,11 @@ sub select_clause {
 
     $sql .= (
         join ', ',
-        map { $_->sql_with_alias($dbh) } $self->select_clause_elements()
+        map {
+            $_->can('sql_for_select_clause')
+                ? $_->sql_for_select_clause($dbh)
+                : $_->sql_with_alias($dbh)
+        } $self->select_clause_elements()
     );
 
     return $sql;

--- a/lib/Fey/Table.pm
+++ b/lib/Fey/Table.pm
@@ -301,6 +301,8 @@ sub sql {
     return $_[1]->quote_identifier( $_[0]->name() );
 }
 
+sub sql_for_select_clause { $_[0]->sql( $_[1] ) . '.*' }
+
 sub sql_with_alias { goto &sql }
 
 sub _build_id { $_[0]->name() }

--- a/lib/Fey/Table/Alias.pm
+++ b/lib/Fey/Table/Alias.pm
@@ -99,6 +99,10 @@ sub primary_key {
 
 sub is_alias {1}
 
+sub sql_for_select_clause {
+    return $_[1]->quote_identifier( $_[0]->alias_name() ) . '.*';
+}
+
 sub sql_with_alias {
     return (  $_[1]->quote_identifier( $_[0]->table()->name() ) . ' AS '
             . $_[1]->quote_identifier( $_[0]->alias_name() ) );

--- a/t/SQL/Select-from-clause.t
+++ b/t/SQL/Select-from-clause.t
@@ -648,7 +648,7 @@ my $dbh = Fey::Test->mock_dbh();
         ->where( $first->column('first_id'), '=', Fey::Placeholder->new() );
     #>>
 
-    my $expect = q{SELECT "fourth"."third_id", "fourth"."fourth_id"};
+    my $expect = q{SELECT "fourth".*};
     $expect .= q{ FROM "second"};
     $expect .= q{ JOIN "first" ON ("second"."first_id" = "first"."first_id")};
     $expect .= q{ JOIN "third" ON ("third"."second_id" = "second"."second_id")};
@@ -747,7 +747,7 @@ my $dbh = Fey::Test->mock_dbh();
         ->where( $t1->column('t1_id'), '=', Fey::Placeholder->new() );
     #>>
 
-    my $expect = q{SELECT "t4"."t3_id", "t4"."t4_id"};
+    my $expect = q{SELECT "t4".*};
     $expect .= q{ FROM "t2"};
     $expect .= q{ JOIN "t1" ON ("t2"."t1_id" = "t1"."t1_id")};
     $expect .= q{ JOIN "t3" ON ("t3"."t2_id" = "t2"."t2_id")};

--- a/t/SQL/Select-select-clause.t
+++ b/t/SQL/Select-select-clause.t
@@ -18,7 +18,7 @@ my $dbh = Fey::Test->mock_dbh();
 
     isa_ok( $select, 'Fey::SQL::Select' );
 
-    my $sql = q{SELECT "User"."email", "User"."user_id", "User"."username"};
+    my $sql = q{SELECT "User".*};
     is(
         $select->select_clause($dbh), $sql,
         'select_clause with one table'
@@ -26,7 +26,7 @@ my $dbh = Fey::Test->mock_dbh();
 
     is_deeply(
         [ map { $_->name() } $select->select_clause_elements() ],
-        [qw( email user_id username )],
+        [qw( User )],
         'select_clause_elements with one table'
     );
 }
@@ -39,8 +39,7 @@ my $dbh = Fey::Test->mock_dbh();
     my $user_alias = $s->table('User')->alias( alias_name => 'UserA' );
     $select->select($user_alias);
 
-    my $sql = q{SELECT "User"."email", "User"."user_id", "User"."username"};
-    $sql .= q{, "UserA"."email", "UserA"."user_id", "UserA"."username"};
+    my $sql = q{SELECT "User".*, "UserA".*};
 
     is(
         $select->select_clause($dbh), $sql,
@@ -55,7 +54,7 @@ my $dbh = Fey::Test->mock_dbh();
     $select->select( $s->table('User') );
 
     my $sql
-        = q{SELECT "User"."user_id", "User"."email", "User"."user_id", "User"."username"};
+        = q{SELECT "User"."user_id", "User".*};
     is(
         $select->select_clause($dbh), $sql,
         'select_clause when first adding column and then table for that column'


### PR DESCRIPTION
Instead of listing every single column, which on tables with many queries leads to gigantic queries, just use a star to select every column, scoped to the table alias.
